### PR TITLE
Add fallback viewer initialization for older MuJoCo versions

### DIFF
--- a/robot.py
+++ b/robot.py
@@ -9,7 +9,7 @@ class InvertedPendulumEnv(gym.Env):
         self.render_mode = render
         self.viewer = None
         if render:
-            self.viewer = mujoco.viewer.launch_passive(self.model, self.data)
+            self.viewer = self._create_viewer()
 
         # 观测空间：关节角度、速度
         self.observation_space = gym.spaces.Box(
@@ -49,5 +49,22 @@ class InvertedPendulumEnv(gym.Env):
 
     def close(self):
         if self.viewer is not None:
-            self.viewer.close()
+            close = getattr(self.viewer, "close", None)
+            if callable(close):
+                close()
+
+    def _create_viewer(self):
+        """Create a viewer compatible with different MuJoCo distributions."""
+        if hasattr(mujoco, "viewer"):
+            return mujoco.viewer.launch_passive(self.model, self.data)
+
+        try:
+            import mujoco_viewer
+        except ImportError as exc:  # pragma: no cover - dependent on environment
+            raise RuntimeError(
+                "MuJoCo viewer support is not available. Install `mujoco`>=2.3.4 "
+                "or add the optional `mujoco_viewer` dependency."
+            ) from exc
+
+        return mujoco_viewer.MujocoViewer(self.model, self.data)
 


### PR DESCRIPTION
## Summary
- add a helper to create a viewer that supports both new and old MuJoCo builds
- guard viewer close calls so shutdown is safe across implementations
- raise a clear error when neither built-in nor mujoco_viewer backends are available

## Testing
- python test.py *(fails: ModuleNotFoundError: stable_baselines3)*

------
https://chatgpt.com/codex/tasks/task_e_68de4b864f08832caef0825bbe4b43c7