### PR TITLE
Use mujoco.viewer import when available

### DIFF
--- a/robot.py
+++ b/robot.py
@@ -55,8 +55,12 @@ class InvertedPendulumEnv(gym.Env):
 
     def _create_viewer(self):
         """Create a viewer compatible with different MuJoCo distributions."""
-        if hasattr(mujoco, "viewer"):
-            return mujoco.viewer.launch_passive(self.model, self.data)
+        try:
+            from mujoco import viewer as mujoco_viewer_module
+        except ImportError:
+            mujoco_viewer_module = None
+        else:
+            return mujoco_viewer_module.launch_passive(self.model, self.data)
 
         try:
             import mujoco_viewer


### PR DESCRIPTION
## Summary
- import `mujoco.viewer` directly when available and launch the passive viewer
- keep the existing fallback to `mujoco_viewer` with the same error message when the import fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de511c69cc832c84ee7500f9a36da1