### PR TITLE
Keep viewer rendering during simulation

### DIFF
--- a/robot.py
+++ b/robot.py
@@ -36,6 +36,8 @@ class InvertedPendulumEnv(gym.Env):
         self.data.ctrl[:] = action
         mujoco.mj_step(self.model, self.data)
 
+        self._render_viewer_frame()
+
         obs = self._get_obs()
         angle = obs[0]
 
@@ -52,11 +54,20 @@ class InvertedPendulumEnv(gym.Env):
             close = getattr(self.viewer, "close", None)
             if callable(close):
                 close()
+            self.viewer = None
+
+    def render(self):
+        """Render a single frame if rendering is enabled."""
+        self._render_viewer_frame()
 
     def _create_viewer(self):
         """Create a viewer compatible with different MuJoCo distributions."""
-        if hasattr(mujoco, "viewer"):
-            return mujoco.viewer.launch_passive(self.model, self.data)
+        try:
+            from mujoco import viewer as mujoco_viewer_module
+        except ImportError:
+            mujoco_viewer_module = None
+        else:
+            return mujoco_viewer_module.launch_passive(self.model, self.data)
 
         try:
             import mujoco_viewer
@@ -67,4 +78,20 @@ class InvertedPendulumEnv(gym.Env):
             ) from exc
 
         return mujoco_viewer.MujocoViewer(self.model, self.data)
+
+    def _render_viewer_frame(self):
+        if self.viewer is None:
+            return
+
+        sync = getattr(self.viewer, "sync", None)
+        if callable(sync):
+            # New mujoco.viewer API
+            if getattr(self.viewer, "is_running", lambda: True)():
+                sync()
+            else:
+                self.close()
+        else:
+            render = getattr(self.viewer, "render", None)
+            if callable(render):
+                render()
 


### PR DESCRIPTION
## Summary
- render MuJoCo viewer frames during each environment step so the window stays open
- add a render helper that supports both `mujoco.viewer` and `mujoco_viewer`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de511c69cc832c84ee7500f9a36da1